### PR TITLE
Fix link for mailinglist

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 					</header>
 					<p>
 						<h3>Willst du mitmachen?</h3>
-						<p>Stelle selbst einen <a href="https://freifunk-stuttgart.de/mitmachen/">Knoten</a> auf, kontaktiere uns über die <a href="#contact">Mailingliste</a> oder komm zum nächsten <a href="#meetup">Treffen</a>!</p>
+						<p>Stelle selbst einen <a href="https://freifunk-stuttgart.de/mitmachen/">Knoten</a> auf, kontaktiere uns über die <a href="https://lists.freifunk-stuttgart.net/listinfo/backnang">Mailingliste</a> oder komm zum nächsten <a href="#meetup">Treffen</a>!</p>
 						<p>Eine Liste kompatibler Freifunk-Router findest du unter <a href="https://darmstadt.freifunk.net/mitmachen/unterstuetzte-geraete/">https://darmstadt.freifunk.net/mitmachen/unterstuetzte-geraete</a></p>
 						<p>Die aktuelle Firmware findest du unter: <a href="https://firmware.freifunk-stuttgart.de/">https://firmware.freifunk-stuttgart.de</a> [<a href="https://firmware.freifunk-stuttgart.de/ng">Beta</a>].
 					</p>


### PR DESCRIPTION
Make it so that the link to the mailinglist in "Kontakt" acutally links to the mailinglist.